### PR TITLE
Reimplemented the checkEdits command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .idea/
 .vscode/
 Storage/
-Testing/
+testing/
 logs/
 workspace.code-workspace
 .env

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 skip_lock = true
 
 [packages]
-"discord.py" = {editable = true, git = "https://github.com/Rapptz/discord.py"}
+"discord.py" = {editable = true, git = "https://github.com/Kshitiz-Arya/discord.py/"}
 pandas = "*"
 pillow = "*"
 motor = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -12,11 +12,13 @@ motor = "*"
 pymongo = {extras = ["srv"], version = "*"}
 aiohttp = "*"
 matplotlib = "*"
+dpytest = "*"
 
 [dev-packages]
 dpytools = "*"
 ipykernel = "*"
 pdoc3 = "*"
+pytest = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c71c5b08e0ac3a59a830942507f3d2501071d08b4282d645b4857f035902120d"
+            "sha256": "73110096d1dc85b1e3ce7e30f99a825fb6126d3fc7cc73fc62e67015a554e179"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -94,7 +94,7 @@
         "discord-py": {
             "editable": true,
             "git": "https://github.com/Rapptz/discord.py",
-            "ref": "c6a6c6af85e01fb16988a82ecc8d37a72622615e"
+            "ref": "29b808d33f02aa1519703f58823de091dc2fe370"
         },
         "discord.py": {
             "editable": true,
@@ -106,6 +106,14 @@
                 "sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d"
             ],
             "version": "==1.16.0"
+        },
+        "dpytest": {
+            "hashes": [
+                "sha256:cfd8afb929bf006972c4bd9c13b36f9dee19a057d4c408b4b6b31acfea340ff4",
+                "sha256:d991909aca44ac095157ddca4e7f68e928e277d19bdc2a9d2908d3346b5ca309"
+            ],
+            "index": "pypi",
+            "version": "==0.5.3"
         },
         "fonttools": {
             "hashes": [
@@ -123,43 +131,62 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.2"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
         "kiwisolver": {
             "hashes": [
-                "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d",
-                "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31",
-                "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9",
-                "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0",
-                "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72",
-                "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3",
-                "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6",
-                "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e",
-                "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000",
-                "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3",
-                "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18",
-                "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21",
-                "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621",
-                "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b",
-                "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc",
-                "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131",
-                "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882",
-                "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454",
-                "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248",
-                "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de",
-                "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598",
-                "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54",
-                "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278",
-                "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6",
-                "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81",
-                "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030",
-                "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8",
-                "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689",
-                "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4",
-                "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0",
-                "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05",
-                "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"
+                "sha256:0007840186bacfaa0aba4466d5890334ea5938e0bb7e28078a0eb0e63b5b59d5",
+                "sha256:19554bd8d54cf41139f376753af1a644b63c9ca93f8f72009d50a2080f870f77",
+                "sha256:1d45d1c74f88b9f41062716c727f78f2a59a5476ecbe74956fafb423c5c87a76",
+                "sha256:1d819553730d3c2724582124aee8a03c846ec4362ded1034c16fb3ef309264e6",
+                "sha256:2210f28778c7d2ee13f3c2a20a3a22db889e75f4ec13a21072eabb5693801e84",
+                "sha256:22521219ca739654a296eea6d4367703558fba16f98688bd8ce65abff36eaa84",
+                "sha256:25405f88a37c5f5bcba01c6e350086d65e7465fd1caaf986333d2a045045a223",
+                "sha256:2b65bd35f3e06a47b5c30ea99e0c2b88f72c6476eedaf8cfbc8e66adb5479dcf",
+                "sha256:2ddb500a2808c100e72c075cbb00bf32e62763c82b6a882d403f01a119e3f402",
+                "sha256:2f8f6c8f4f1cff93ca5058d6ec5f0efda922ecb3f4c5fb76181f327decff98b8",
+                "sha256:30fa008c172355c7768159983a7270cb23838c4d7db73d6c0f6b60dde0d432c6",
+                "sha256:3dbb3cea20b4af4f49f84cffaf45dd5f88e8594d18568e0225e6ad9dec0e7967",
+                "sha256:4116ba9a58109ed5e4cb315bdcbff9838f3159d099ba5259c7c7fb77f8537492",
+                "sha256:44e6adf67577dbdfa2d9f06db9fbc5639afefdb5bf2b4dfec25c3a7fbc619536",
+                "sha256:5326ddfacbe51abf9469fe668944bc2e399181a2158cb5d45e1d40856b2a0589",
+                "sha256:70adc3658138bc77a36ce769f5f183169bc0a2906a4f61f09673f7181255ac9b",
+                "sha256:72be6ebb4e92520b9726d7146bc9c9b277513a57a38efcf66db0620aec0097e0",
+                "sha256:7843b1624d6ccca403a610d1277f7c28ad184c5aa88a1750c1a999754e65b439",
+                "sha256:7ba5a1041480c6e0a8b11a9544d53562abc2d19220bfa14133e0cdd9967e97af",
+                "sha256:80efd202108c3a4150e042b269f7c78643420cc232a0a771743bb96b742f838f",
+                "sha256:82f49c5a79d3839bc8f38cb5f4bfc87e15f04cbafa5fbd12fb32c941cb529cfb",
+                "sha256:83d2c9db5dfc537d0171e32de160461230eb14663299b7e6d18ca6dca21e4977",
+                "sha256:8d93a1095f83e908fc253f2fb569c2711414c0bfd451cab580466465b235b470",
+                "sha256:8dc3d842fa41a33fe83d9f5c66c0cc1f28756530cd89944b63b072281e852031",
+                "sha256:9661a04ca3c950a8ac8c47f53cbc0b530bce1b52f516a1e87b7736fec24bfff0",
+                "sha256:a498bcd005e8a3fedd0022bb30ee0ad92728154a8798b703f394484452550507",
+                "sha256:a7a4cf5bbdc861987a7745aed7a536c6405256853c94abc9f3287c3fa401b174",
+                "sha256:b5074fb09429f2b7bc82b6fb4be8645dcbac14e592128beeff5461dcde0af09f",
+                "sha256:b6a5431940f28b6de123de42f0eb47b84a073ee3c3345dc109ad550a3307dd28",
+                "sha256:ba677bcaff9429fd1bf01648ad0901cea56c0d068df383d5f5856d88221fe75b",
+                "sha256:bcadb05c3d4794eb9eee1dddf1c24215c92fb7b55a80beae7a60530a91060560",
+                "sha256:bf7eb45d14fc036514c09554bf983f2a72323254912ed0c3c8e697b62c4c158f",
+                "sha256:c358721aebd40c243894298f685a19eb0491a5c3e0b923b9f887ef1193ddf829",
+                "sha256:c4550a359c5157aaf8507e6820d98682872b9100ce7607f8aa070b4b8af6c298",
+                "sha256:c6572c2dab23c86a14e82c245473d45b4c515314f1f859e92608dcafbd2f19b8",
+                "sha256:cba430db673c29376135e695c6e2501c44c256a81495da849e85d1793ee975ad",
+                "sha256:dedc71c8eb9c5096037766390172c34fb86ef048b8e8958b4e484b9e505d66bc",
+                "sha256:e6f5eb2f53fac7d408a45fbcdeda7224b1cfff64919d0f95473420a931347ae9",
+                "sha256:ec2eba188c1906b05b9b49ae55aae4efd8150c61ba450e6721f64620c50b59eb",
+                "sha256:ee040a7de8d295dbd261ef2d6d3192f13e2b08ec4a954de34a6fb8ff6422e24c",
+                "sha256:eedd3b59190885d1ebdf6c5e0ca56828beb1949b4dfe6e5d0256a461429ac386",
+                "sha256:f441422bb313ab25de7b3dbfd388e790eceb76ce01a18199ec4944b369017009",
+                "sha256:f8eb7b6716f5b50e9c06207a14172cf2de201e41912ebe732846c02c830455b9",
+                "sha256:fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.3.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.2"
         },
         "matplotlib": {
             "hashes": [
@@ -354,6 +381,22 @@
             "index": "pypi",
             "version": "==8.3.1"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:265a94bf44ca13662f12fcd1b074c14d4b269a712f051b6f644ef7e705d6735f",
+                "sha256:467f0219e89bb5061a8429c6fc5cf055fa3983a0e68e84a1d205046306b37d9e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.0.0.dev0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
         "pymongo": {
             "extras": [
                 "srv"
@@ -469,6 +512,22 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.0.0b3"
         },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2.4"
+        },
+        "pytest-asyncio": {
+            "hashes": [
+                "sha256:2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f",
+                "sha256:3042bcdf1c5d978f6b74d96a151c4cfb9dcece65006198389ccd7e6c60eb1eea"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.15.1"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
@@ -499,6 +558,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
         },
         "typing-extensions": {
             "hashes": [
@@ -725,6 +792,13 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.2"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
         "ipykernel": {
             "hashes": [
                 "sha256:35cc31accec420e90c4b66ea7f4e7b067c769e31af3502e45326c6f1294d238d",
@@ -907,6 +981,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.5.1"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
+        },
         "parso": {
             "hashes": [
                 "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398",
@@ -937,6 +1019,14 @@
             ],
             "version": "==0.7.5"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:265a94bf44ca13662f12fcd1b074c14d4b269a712f051b6f644ef7e705d6735f",
+                "sha256:467f0219e89bb5061a8429c6fc5cf055fa3983a0e68e84a1d205046306b37d9e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.0.0.dev0"
+        },
         "prompt-toolkit": {
             "hashes": [
                 "sha256:6076e46efae19b1e0ca1ec003ed37a933dc94b4d20f486235d436e64771dcd5c",
@@ -952,6 +1042,14 @@
             ],
             "version": "==0.7.0"
         },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
         "pygments": {
             "hashes": [
                 "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380",
@@ -959,6 +1057,22 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==2.10.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:10f1886e70da7b76ca1b4cf9bbd60f708ef037892496d5cb7c77ab2982412b2d",
+                "sha256:e96a96967098a5221a78bf94d72930cd1cfaf0ab88dae2ea6bfc2b8b8ccb1930"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.0.0b3"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2.4"
         },
         "python-dateutil": {
             "hashes": [
@@ -1018,6 +1132,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
         },
         "tornado": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "73110096d1dc85b1e3ce7e30f99a825fb6126d3fc7cc73fc62e67015a554e179"
+            "sha256": "eb24a845e5a1b7895b857b6f03282acf953172013542f64ae2c4d4586a7e6b1e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -93,12 +93,12 @@
         },
         "discord-py": {
             "editable": true,
-            "git": "https://github.com/Rapptz/discord.py",
-            "ref": "29b808d33f02aa1519703f58823de091dc2fe370"
+            "git": "https://github.com/Kshitiz-Arya/discord.py/",
+            "ref": "45d498c1b76deaf3b394d17ccf56112fa691d160"
         },
         "discord.py": {
             "editable": true,
-            "git": "https://github.com/Rapptz/discord.py"
+            "git": "https://github.com/Kshitiz-Arya/discord.py/"
         },
         "dnspython": {
             "hashes": [
@@ -569,11 +569,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:045dd532231acfa03628df5e0c66dba64e2cc8fc8b844538d4ad6d5dd6cb82dc",
+                "sha256:83af6730a045fda60f46510f7f1f094776d90321caa4d97d20ef38871bef4bd3",
+                "sha256:8bbffbd37fbeb9747a0241fdfde5ae99d4531ad1d1a41ccaea62100e15a5814c"
             ],
-            "version": "==3.10.0.0"
+            "version": "==3.10.0.1"
         },
         "yarl": {
             "hashes": [
@@ -766,7 +766,7 @@
         },
         "discord.py": {
             "editable": true,
-            "git": "https://github.com/Rapptz/discord.py"
+            "git": "https://github.com/Kshitiz-Arya/discord.py/"
         },
         "dpytools": {
             "hashes": [
@@ -809,11 +809,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:0cff04bb042800129348701f7bd68a430a844e8fb193979c08f6c99f28bb735e",
-                "sha256:892743b65c21ed72b806a3a602cca408520b3200b89d1924f4b3d2cdb3692362"
+                "sha256:58b55ebfdfa260dad10d509702dc2857cb25ad82609506b070cf2d7b7df5af13",
+                "sha256:75b5e060a3417cf64f138e0bb78e58512742c57dc29db5a5058a2b1f0c10df02"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.26.0"
+            "version": "==7.27.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -832,11 +832,11 @@
         },
         "jupyter-client": {
             "hashes": [
-                "sha256:07b9566979546004c089afe7c9bf9e96224ec5f8421fe0ae460759fa593c6b1d",
-                "sha256:48822a93d9d75daa5fde235c35cf7a92fc979384735962501d4eb60b197fb43a"
+                "sha256:0c6cabd07e003a2e9692394bf1ae794188ad17d2e250ed747232d7a473aa772c",
+                "sha256:37a30c13d3655b819add61c830594090af7fca40cd2d74f41cad9e2e12118501"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==7.0.1"
+            "version": "==7.0.2"
         },
         "jupyter-core": {
             "hashes": [
@@ -1198,11 +1198,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:045dd532231acfa03628df5e0c66dba64e2cc8fc8b844538d4ad6d5dd6cb82dc",
+                "sha256:83af6730a045fda60f46510f7f1f094776d90321caa4d97d20ef38871bef4bd3",
+                "sha256:8bbffbd37fbeb9747a0241fdfde5ae99d4531ad1d1a41ccaea62100e15a5814c"
             ],
-            "version": "==3.10.0.0"
+            "version": "==3.10.0.1"
         },
         "wcwidth": {
             "hashes": [

--- a/cogs/commands/basic.py
+++ b/cogs/commands/basic.py
@@ -35,8 +35,7 @@ class Basic(commands.Cog):
                    ctx: commands.Context,
                    chapter,
                    *,
-                   edit: EditConverter,
-                   context=0) -> Optional[bool]:
+                   edit: EditConverter) -> Optional[bool]:
         """This command takes editorial request from the editors and post it in the assigned channel.
 
         Args:
@@ -134,7 +133,6 @@ class Basic(commands.Cog):
         else:
             await ctx.reply("Editing is currently disabled for this chapter.",
                             delete_after=10)
-            return False
 
     @in_channel()
     @commands.command()

--- a/cogs/commands/basic.py
+++ b/cogs/commands/basic.py
@@ -130,8 +130,7 @@ class Basic(commands.Cog):
                             delete_after=10,
                             mention_author=False)
             return True
-        else:
-            await ctx.reply("Editing is currently disabled for this chapter.",
+        await ctx.reply("Editing is currently disabled for this chapter.",
                             delete_after=10)
 
     @in_channel()

--- a/cogs/commands/basic.py
+++ b/cogs/commands/basic.py
@@ -71,20 +71,18 @@ class Basic(commands.Cog):
                 return
 
             channel_id = ctx.channel.id
-            if context == 0:
-                mID = ctx.message.id
-                aID = ctx.author.id
-                author_name = (ctx.author.name
-                               if ctx.author.nick is None else ctx.author.nick)
-                avatar = ctx.author.avatar.url
+            mID = ctx.message.id
+            aID = ctx.author.id
+            avatar = ctx.author.avatar.url
 
-            else:
-                mID = context.message.id
-                aID = context.author.id
-                author_name = context.author.name
-                avatar = context.author.avatar.url
+            try:
+                author_name = ctx.author.name if (
+                    nick := ctx.author.nick) is None else nick
+            except AttributeError:
+                author_name = ctx.author.name
 
             book = Book(chapter, guild)
+            current_time = datetime.now()
             editorial_channel_id, msg_stats = allowedEdits[chapter]
             editorial_channel = self.client.get_channel(editorial_channel_id)
 
@@ -121,6 +119,7 @@ class Basic(commands.Cog):
                 'org_channel_id': channel_id,
                 'edit_channel_id': editorial_channel_id,
                 'status': 'Not Voted Yet',
+                'time': current_time,
                 'type': 'edit'
             }
             await db.insert(guild.id, "editorial", insert_statement)
@@ -128,14 +127,14 @@ class Basic(commands.Cog):
             await update_stats(self.client.user, chapter, guild,
                                editorial_channel, msg_stats)
 
-            if not context:
-                await ctx.reply("Your edit has been accepted.",
-                                delete_after=10,
-                                mention_author=False)
+            await ctx.reply("Your edit has been accepted.",
+                            delete_after=10,
+                            mention_author=False)
             return True
-        if not context:
+        else:
             await ctx.reply("Editing is currently disabled for this chapter.",
                             delete_after=10)
+            return False
 
     @in_channel()
     @commands.command()

--- a/cogs/mods/mods.py
+++ b/cogs/mods/mods.py
@@ -701,7 +701,6 @@ class Mods(commands.Cog):
         Example:
             >checkEdits 2 :- Hermione will look for edits in last 2 days of message history
         """
-
         count = 0
         guild = ctx.guild
         channel = ctx.channel

--- a/cogs/mods/mods.py
+++ b/cogs/mods/mods.py
@@ -757,6 +757,21 @@ class Mods(commands.Cog):
     #     if conn:
     #         conn.close()
 
+def extract_edits(message: discord.Message, prefix='>') -> dict:
+    """Return a dict of the command type, chapter and edit/suggestion
+
+    Args:
+        message (discord.Message): [Represents a Discord message.]
+
+    Returns:
+        [dict]
+    """
+    # prefix = message.context.clean_prefix
+    command, chapter, args = message.content.split(maxsplit=2)
+    msg_id = message.id
+    # remove prefix from command using a string method
+    return {'agrs': args, 'chapter': chapter, 'id': msg_id, 'message': message, 'type': command.removeprefix(prefix)}
+
     @commands.command(aliases=["changeColor"])
     @in_channel()
     @is_author()
@@ -1100,28 +1115,10 @@ def filter_commands(message: discord.Message, prefix='>') -> bool:
     # prefix = message.context.clean_prefix
     return message.content.startswith(prefix+'edit ') or message.content.startswith(prefix+'suggest ')
 
-
-def extract_edits(message: discord.Message, prefix='>') -> dict:
-    """Return a dict of the command type, chapter and edit/suggestion
-
-    Args:
-        message (discord.Message): [Represents a Discord message.]
-
-    Returns:
-        [dict]
-    """
-    # prefix = message.context.clean_prefix
-    command, chapter, args = message.content.split(maxsplit=2)
-    msg_id = message.id
-    # remove prefix from command using a string method
-    return {'agrs': args, 'chapter': chapter, 'id': msg_id, 'message': message, 'type': command.removeprefix(prefix)}
-
 ###############################################################################
 #                         AREA FOR SETUP                                      #
 ###############################################################################
 
 # skipcq: PY-D0003
-
-
 def setup(client):
     client.add_cog(Mods(client))

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import sys
@@ -126,14 +125,14 @@ for direct in os.listdir("./cogs"):
 
 
 @client.event
-async def on_message(meg):
+async def on_message(msg):
     """This event triggers when a message is sent in a server
 
     Args:
         meg (discord.Message): The message that was sent
     """
-    if meg.guild:
-        ctx = await client.get_context(meg)
+    if msg.guild:
+        ctx = await client.get_context(msg)
         await client.invoke(ctx)
     else:
         pass

--- a/main.py
+++ b/main.py
@@ -1,14 +1,14 @@
-from discord import client
-from cogs.mods.error import send
 import json
 import logging
 import os
 import sys
 
+from discord import client
 from discord.ext import commands
-from discord.ext.commands.core import check, is_owner
-from packages.pretty_help import PrettyHelp
+from discord.ext.commands.core import is_owner
+
 from packages.command import PersistentView
+from packages.pretty_help import PrettyHelp
 
 logger = logging.getLogger('discord')
 logger.setLevel(20)

--- a/packages/database.py
+++ b/packages/database.py
@@ -40,7 +40,7 @@ async def get_document(guild_id, database, query, return_column, connect=connect
     return return_doucment
 
 
-async def get_documents(guild, database, query: dict, return_column: list, limit=0, connect=connection):
+async def get_documents(guild_id, database, query: dict, return_column: list, limit=0, connect=connection):
     """Get multiple documents from a database
 
     Args:
@@ -54,11 +54,10 @@ async def get_documents(guild, database, query: dict, return_column: list, limit
     Returns:
         list: A list of documents
     """
-    collections = connect[database][guild.id]
+    collections = connect[database][str(guild_id)]
     document = {column: 1 for column in return_column}
-    num_document = await collections.count_documents(query)
 
-    return await collections.find(query, document, limit=limit).to_list(num_document)
+    return await collections.find(query, document, limit=limit).to_list(None)
 
 
 async def get_stats(guild, database: str, chapter: int = None, connect=connection):


### PR DESCRIPTION
## Summary
This PR is mainly for the reimplementation of the `checkEdits` command, which now has 50% fewer code lines. The current implementation only has 15 lines of code, which is much better than the over-engineered mess it was before.

The other changes are as follows

- Now using a forked version of discord.py (RIP dpy)
- Removed an argument context from the `edit` command as it was there for the earlier version of the `checkEdits` command
- The editorial documents now also stores the edit request time.
- The `get_documents` function now takes **guild_id** instead of guild object

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
